### PR TITLE
Conditioning the headers_in.content_encoding to nginx_version less than 1023000

### DIFF
--- a/ngx_http_redis_module.c
+++ b/ngx_http_redis_module.c
@@ -604,7 +604,7 @@ found:
             ngx_str_set(&h->key, "Content-Encoding");
             ngx_str_set(&h->value, "gzip");
             h->lowcase_key = (u_char*) "content-encoding";
-#if (NGX_HTTP_GZIP)
+#if (NGX_HTTP_GZIP && nginx_version < 1023000)
             u->headers_in.content_encoding = h;
 #endif
         }


### PR DESCRIPTION
Since Nginx 1.23.0 the function ngx_http_upstream_copy_content_encoding was stripped out from the source code because @mdounin thought this function was equivalent to ngx_http_upstream_copy_header_line and I think he is right (https://github.com/nginx/nginx/commit/25093473051cae249963ace3156900dcc7ef5fae), then the field content_encoding inside the http_upstream_headers_in_t conditioned to NGX_HTTP_GZIP was removed. This change broke my build using Nginx 1.23.3 and http_redis_0.3.9, since http_redis has the same if statement setting a value to u->headers_in.content_encoding conditioned to NGX_HTT_GZIP.

This commit adds a new condition to the if statement where the nginx_version must be less than 1023000 (nginx 1.23.0).
I tested this current change I did with all 1.23.[0-3] versions so far and 1.22.0.